### PR TITLE
Delete CNAME

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,0 @@
-escolhaumalicenca.com.br


### PR DESCRIPTION
escolhaumalicenca.com.br is not available. But we can use gh-pages.